### PR TITLE
Ease coding with Python3

### DIFF
--- a/neubot_http/blocking.py
+++ b/neubot_http/blocking.py
@@ -9,6 +9,7 @@
 
 from .mixins import HTTPRequestHandlerMixin
 from .mixins import HTTPServerMixin
+from .outqueue import HTTPOutputQueue
 from .parser import HTTPParser
 
 class _RequestHandler(HTTPRequestHandlerMixin):
@@ -31,21 +32,19 @@ class _RequestHandler(HTTPRequestHandlerMixin):
     def handle(self):
         """ Called to handle the request """
         parser = HTTPParser()
+        outqueue = HTTPOutputQueue()
         while True:
             data = self.request.recv(65535)
             if data:
                 parser.feed(data)
             else:
                 parser.eof()
-            while True:
+            result = parser.parse()
+            while result:
+                outqueue.insert_data(self.emit(result))
                 result = parser.parse()
-                if not result:
-                    break
-                to_send = self.emit(result)
-                if not to_send:
-                    continue
-                for piece in to_send:
-                    self.request.sendall(piece)
+            while outqueue:
+                self.request.sendall(outqueue.get_next_chunk())
             if not data:
                 break
 

--- a/neubot_http/blocking.py
+++ b/neubot_http/blocking.py
@@ -44,7 +44,9 @@ class _RequestHandler(HTTPRequestHandlerMixin):
                 outqueue.insert_data(self.emit(result))
                 result = parser.parse()
             while outqueue:
-                self.request.sendall(outqueue.get_next_chunk())
+                chunk = outqueue.get_next_chunk()
+                if chunk:
+                    self.request.sendall(chunk)
             if not data:
                 break
 

--- a/neubot_http/messages.py
+++ b/neubot_http/messages.py
@@ -1,0 +1,67 @@
+#
+# This file is part of Neubot <https://www.neubot.org/>.
+#
+# Neubot is free software. See AUTHORS and LICENSE for more
+# information on the copying conditions.
+#
+
+""" HTTP messages """
+
+class HTTPMessage(object):
+    """ HTTP message object """
+
+    def __init__(self):
+        self.method = ""
+        self.url = ""
+        self.protocol = ""
+        self.code = ""
+        self.reason = ""
+        self.headers = {}
+        self.bodyv = []
+
+    @staticmethod
+    def request(method, url, protocol, headers):
+        """ Constructs a request message """
+        message = HTTPMessage()
+        message.method = method
+        message.url = url
+        message.protocol = protocol
+        message.headers = headers
+        return message
+
+    @staticmethod
+    def response(protocol, code, reason, headers):
+        """ Constructs a response message """
+        message = HTTPMessage()
+        message.protocol = protocol
+        message.code = code
+        message.reason = reason
+        message.headers = headers
+        return message
+
+    def __getattr__(self, key):
+        return self.headers[key.lower()]
+
+    def add_body_chunk(self, chunk):
+        """ Add chunk to body """
+        self.bodyv.append(chunk)
+
+    def body_as_string(self, encoding=None):
+        """ Return the body as string """
+        binary = b"".join(self.bodyv)
+        if encoding:
+            return binary.decode(encoding)
+        content_type = self["content-type"].lower()
+        index = content_type.find("charset=")
+        if index >= 0:
+            encoding = content_type[index + len("charset="):].strip()
+            return binary.decode(encoding)
+        if content_type == "application/json":
+            return binary.decode("utf-8")
+        if content_type == "application/xml":
+            return binary.decode("utf-8")
+        return binary.decode("iso-8859-1")  # Default
+
+    def body_as_bytes(self):
+        """ Return the body as bytes """
+        return b"".join(self.bodyv)

--- a/neubot_http/messages.py
+++ b/neubot_http/messages.py
@@ -40,7 +40,10 @@ class HTTPMessage(object):
         return message
 
     def __getitem__(self, key):
-        return self.headers[key.lower()]
+        key = key.lower()
+        if key not in self.headers:
+            return ""
+        return self.headers[key]
 
     def add_body_chunk(self, chunk):
         """ Add chunk to body """

--- a/neubot_http/messages.py
+++ b/neubot_http/messages.py
@@ -39,7 +39,7 @@ class HTTPMessage(object):
         message.headers = headers
         return message
 
-    def __getattr__(self, key):
+    def __getitem__(self, key):
         return self.headers[key.lower()]
 
     def add_body_chunk(self, chunk):

--- a/neubot_http/mixins.py
+++ b/neubot_http/mixins.py
@@ -45,11 +45,10 @@ class HTTPRequestHandlerMixin(object):
 
     def on_request_begin(self, request):
         """ Override to filter requests by headers """
-        request["body"] = []
 
     def on_request_data(self, request, data):
         """ Override to ignore incoming body """
-        request["body"].append(data)
+        request.add_body_chunk(data)
 
     def on_request_end(self, request):
         """ Override to process complete requests """

--- a/neubot_http/nonblocking.py
+++ b/neubot_http/nonblocking.py
@@ -41,9 +41,10 @@ class _RequestHandler(asyncore.dispatcher, HTTPRequestHandlerMixin):
 
     def handle_write(self):
         chunk = self.queue.get_next_chunk()
-        chunk = chunk[self.send(chunk):]
         if chunk:
-            self.reinsert_partial_chunk(chunk)
+            chunk = chunk[self.send(chunk):]
+            if chunk:
+                self.reinsert_partial_chunk(chunk)
 
 class HTTPServerNonblocking(asyncore.dispatcher, HTTPServerMixin):
     """ Nonblocking HTTP server """

--- a/neubot_http/nonblocking.py
+++ b/neubot_http/nonblocking.py
@@ -8,11 +8,11 @@
 """ Nonblocking code """
 
 import asyncore
-import collections
 import logging
 
 from .mixins import HTTPRequestHandlerMixin
 from .mixins import HTTPServerMixin
+from .outqueue import HTTPOutputQueue
 from .parser import HTTPParser
 
 class _RequestHandler(asyncore.dispatcher, HTTPRequestHandlerMixin):
@@ -22,7 +22,7 @@ class _RequestHandler(asyncore.dispatcher, HTTPRequestHandlerMixin):
         asyncore.dispatcher.__init__(self, sock, mapx)
         HTTPRequestHandlerMixin.__init__(self, router)
         self.parser = HTTPParser()
-        self.obuff = collections.deque()
+        self.queue = HTTPOutputQueue()
 
     def handle_read(self):
         data = self.recv(65535)
@@ -31,35 +31,19 @@ class _RequestHandler(asyncore.dispatcher, HTTPRequestHandlerMixin):
             self.parser.feed(data)
         else:
             self.parser.eof()
-        while True:
+        result = self.parser.parse()
+        while result:
+            self.queue.insert_data(self.emit(result))
             result = self.parser.parse()
-            if not result:
-                break
-            to_send = self.emit(result)
-            if to_send:
-                self.obuff.append(to_send)
 
     def writable(self):
-        return bool(self.obuff)
+        return bool(self.queue)
 
     def handle_write(self):
-        while self.obuff:
-            selected = self.obuff[0]
-            if isinstance(selected, bytes):
-                if selected:
-                    break
-                self.obuff.popleft()
-                continue
-            try:
-                data = next(selected)
-            except StopIteration:
-                self.obuff.popleft()
-            else:
-                if data:
-                    self.obuff.appendleft(data)
-                    break
-        if self.obuff:
-            self.obuff[0] = data[self.send(self.obuff[0]):]
+        chunk = self.queue.get_next_chunk()
+        chunk = chunk[self.send(chunk):]
+        if chunk:
+            self.reinsert_partial_chunk(chunk)
 
 class HTTPServerNonblocking(asyncore.dispatcher, HTTPServerMixin):
     """ Nonblocking HTTP server """

--- a/neubot_http/outqueue.py
+++ b/neubot_http/outqueue.py
@@ -1,0 +1,67 @@
+#
+# This file is part of Neubot <https://www.neubot.org/>.
+#
+# Neubot is free software. See AUTHORS and LICENSE for more
+# information on the copying conditions.
+#
+
+""" Output queue """
+
+import collections
+
+class HTTPOutputQueue(object):
+    """ Output queue """
+
+    def __init__(self, default_encoding="iso-8859-1"):
+        self.queue = collections.deque()
+        self.default_encoding = default_encoding
+
+    def insert_data(self, data):
+        """
+         Insert data to be sent.
+
+         The inserted element shall be an instance of `bytes`, an instance
+         of `str`, or an iterator. In the latter case, the iterator shall
+         return instances of `bytes`, instances of `str` or another iterator
+         that shall return instances of `bytes`, of `str` or, in turn,
+         another iterator to which the same restrictions apply.
+
+         If the inserted element is empty, nothing is inserted in queue.
+        """
+        if data:
+            self.queue.append(data)
+
+    def reinsert_partial_chunk(self, chunk):
+        """
+         Reinsert partially sent chunk on the left side of the queue.
+
+         The inserted element is coerced to memoryview.
+        """
+        self.queue.appendleft(memoryview(chunk))
+
+    def get_next_chunk(self):
+        """
+         Extract element from the left side of the queue.
+
+         Returns a memoryview that could be passed to send() and similar
+         functions, or `None` when the queue is empty.
+        """
+        while self.queue:
+            try:
+                elem = next(self.queue[0])
+            except StopIteration:
+                self.queue.popleft()
+            except TypeError:
+                if elem:
+                    if isinstance(elem, str):
+                        elem = elem.encode(self.default_encoding)
+                    elem = memoryview(elem)
+                    return elem
+            else:
+                self.queue.appendleft(elem)
+
+    def __bool__(self):
+        return bool(self.queue)
+
+    def __len__(self):
+        return len(self.queue)

--- a/neubot_http/outqueue.py
+++ b/neubot_http/outqueue.py
@@ -52,6 +52,7 @@ class HTTPOutputQueue(object):
             except StopIteration:
                 self.queue.popleft()
             except TypeError:
+                elem = self.queue.popleft()
                 if elem:
                     if isinstance(elem, str):
                         elem = elem.encode(self.default_encoding)

--- a/neubot_http/parser.py
+++ b/neubot_http/parser.py
@@ -46,13 +46,18 @@ class HTTPParser(object):
             pos = data.find(b"\n")
             if pos == -1:
                 if len(data) > maxline:
-                    return -1, b""
-                return 0, b""
+                    return -1, ""
+                return 0, ""
             else:
                 pos += 1
         else:
             pos += 2
         line = data[:pos]
+        #
+        # If I understand RFC2616 Sect. 2.2 correctly, <TEXT> must
+        # be ISO-8859-1, otherwise it must be MIME encoded.
+        #
+        line = line.decode("iso-8859-1")
         self.incoming = [data[pos:]]
         return len(line), line
 
@@ -62,7 +67,7 @@ class HTTPParser(object):
         if length < 0:
             raise HTTPError
         if length == 0:
-            return b""
+            return ""
         logging.debug("< %s", line.strip())
         return line
 
@@ -89,15 +94,15 @@ class HTTPParser(object):
             if len(first_line) != 3:
                 raise HTTPError
 
-            if first_line[0].startswith(b"HTTP/"):
+            if first_line[0].startswith("HTTP/"):
                 isresponse = True
-            elif first_line[2].startswith(b"HTTP/"):
+            elif first_line[2].startswith("HTTP/"):
                 isresponse = False
             else:
                 raise HTTPError
 
             logging.debug("* HEADERS")
-            last_hdr = b""
+            last_hdr = ""
             headers = {}
             while True:
                 if len(headers) > self.maxheaders:
@@ -109,14 +114,14 @@ class HTTPParser(object):
                 line = line.strip()
                 if not line:
                     break
-                if last_hdr and line[0:1] in (b" ", b"\t"):
+                if last_hdr and line[0:1] in (" ", "\t"):
                     # Must be first branch so ":" can appear in folded lines
-                    value = headers[last_hdr] + b" " + line
+                    value = headers[last_hdr] + " " + line
                 else:
-                    pos = line.find(b":")
+                    pos = line.find(":")
                     if pos < 0:
                         raise HTTPError
-                    last_hdr, value = line.split(b":", 1)
+                    last_hdr, value = line.split(":", 1)
                     last_hdr, value = last_hdr.strip().lower(), value.strip()
                 headers[last_hdr] = value
 
@@ -139,7 +144,7 @@ class HTTPParser(object):
 
             yield (message["type"], message)
 
-            if headers.get(b"transfer-encoding") == b"chunked":
+            if headers.get("transfer-encoding") == "chunked":
 
                 while True:
 
@@ -183,10 +188,10 @@ class HTTPParser(object):
 
                 yield ("end", message)
 
-            elif headers.get(b"content-length"):
+            elif headers.get("content-length"):
 
                 logging.debug("* BOUNDED_BODY")
-                length = int(headers[b"content-length"])
+                length = int(headers["content-length"])
                 if length < 0:
                     raise HTTPError
                 while length > 0:
@@ -198,14 +203,14 @@ class HTTPParser(object):
                     yield ("data", message, data)
                 yield ("end", message)
 
-            elif isresponse and (first_line[1][0:1] == b"1" or
-                                 first_line[1] == b"204" or
-                                 first_line[1] == b"304"):
+            elif isresponse and (first_line[1][0:1] == "1" or
+                                 first_line[1] == "204" or
+                                 first_line[1] == "304"):
                 logging.debug("* 100_OR_2O4_OR_304")
                 yield ("end", message)
 
-            elif isresponse and (headers.get(b"connection") != b"keep-alive" or
-                                 first_line[0] == b"HTTP/1.0"):
+            elif isresponse and (headers.get("connection") != "keep-alive" or
+                                 first_line[0] == "HTTP/1.0"):
                 logging.debug("* CONNECTION_CLOSE")
                 while not self.eof_flag:
                     data = self._read(65535)
@@ -217,9 +222,9 @@ class HTTPParser(object):
                 yield ("end", message)
                 return  # Reached final state
 
-            elif isresponse and (first_line[1][0:1] == b"1" or
-                                 first_line[1] == b"204" or
-                                 first_line[1] == b"304"):
+            elif isresponse and (first_line[1][0:1] == "1" or
+                                 first_line[1] == "204" or
+                                 first_line[1] == "304"):
                 logging.debug("* RESPONSE_WITHOUT_BODY")
                 yield ("end", message)
 

--- a/neubot_http/parser.py
+++ b/neubot_http/parser.py
@@ -9,6 +9,8 @@
 
 import logging
 
+from .messages import HTTPMessage
+
 class HTTPError(RuntimeError):
     """ Indicates a protocol error """
 
@@ -126,21 +128,11 @@ class HTTPParser(object):
                 headers[last_hdr] = value
 
             if isresponse:
-                message = {
-                    "type": "response",
-                    "protocol": first_line[0],
-                    "code": first_line[1],
-                    "reason": first_line[2],
-                    "headers": headers,
-                }
+                message = HTTPMessage.response(first_line[0], first_line[1],
+                                               first_line[2], headers)
             else:
-                message = {
-                    "type": "request",
-                    "method": first_line[0],
-                    "url": first_line[1],
-                    "protocol": first_line[2],
-                    "headers": headers,
-                }
+                message = HTTPMessage.request(first_line[0], first_line[1],
+                                              first_line[2], headers)
 
             yield (message["type"], message)
 

--- a/neubot_http/parser.py
+++ b/neubot_http/parser.py
@@ -130,11 +130,11 @@ class HTTPParser(object):
             if isresponse:
                 message = HTTPMessage.response(first_line[0], first_line[1],
                                                first_line[2], headers)
+                yield ("response", message)
             else:
                 message = HTTPMessage.request(first_line[0], first_line[1],
                                               first_line[2], headers)
-
-            yield (message["type"], message)
+                yield ("request", message)
 
             if headers.get("transfer-encoding") == "chunked":
 

--- a/neubot_http/router.py
+++ b/neubot_http/router.py
@@ -29,7 +29,7 @@ class HTTPRouter(object):
     def route(self, request):
         """ Route request """
 
-        url = request["url"]
+        url = request.url
         logging.debug("http: router received url: %s", url)
         index = url.find("?")
         if index >= 0:

--- a/neubot_http/router.py
+++ b/neubot_http/router.py
@@ -20,7 +20,7 @@ class HTTPRouter(object):
 
     def add_route(self, url, generator):
         """ Add a route to the router """
-        self.routes[url.encode("utf-8")] = generator
+        self.routes[url] = generator
 
     def add_default_route(self, generator):
         """ Add the default route """
@@ -31,7 +31,7 @@ class HTTPRouter(object):
 
         url = request["url"]
         logging.debug("http: router received url: %s", url)
-        index = url.find(b"?")
+        index = url.find("?")
         if index >= 0:
             url = url[:index]
             logging.debug("http: router url without query: %s", url)

--- a/neubot_http/serializer.py
+++ b/neubot_http/serializer.py
@@ -14,7 +14,7 @@ def compose(first_line, headers, before, filep, after):
     """ Compose a generic HTTP message """
 
     logging.debug("> %s", first_line)
-    yield first_line.encode("utf-8") + b"\r\n"
+    yield first_line + "\r\n"
 
     tot = 0
     if before:
@@ -31,8 +31,8 @@ def compose(first_line, headers, before, filep, after):
         if value is not None:
             logging.debug("> %s: %s", name, value)
             header = "%s: %s\r\n" % (name, value)
-            yield header.encode("utf-8")
-    yield b"\r\n"
+            yield header
+    yield "\r\n"
 
     if before:
         yield before
@@ -46,8 +46,6 @@ def compose(first_line, headers, before, filep, after):
 
 def compose_response(code, reason, headers, body):
     """ Compose a generic HTTP message """
-    if body is not None and not isinstance(body, bytes):
-        body = body.encode("utf-8")
     return compose("HTTP/1.1 %s %s" % (code, reason),
                    headers, body, None, None)
 
@@ -69,7 +67,7 @@ def compose_error(code, reason):
         </HTML>
         """ % locals()
     return compose_response(code, reason, {
-        "Content-Type": "text/html; charset=utf-8",
+        "Content-Type": "text/html",
     }, body)
 
 def compose_headers(code, reason, headers):
@@ -100,4 +98,4 @@ def compose_chunk(chunk):
     logging.debug("> {%d bytes}", len(chunk))
     yield chunk
     logging.debug(">")
-    yield b"\r\n"
+    yield "\r\n"

--- a/neubot_http/www_handler.py
+++ b/neubot_http/www_handler.py
@@ -59,9 +59,9 @@ class WWWHandler(object):
             logging.warning("www: rootdir is not set")
             return serializer.compose_error(403, "Forbidden")
 
-        logging.debug("www: requested to serve: %s", request["url"])
+        logging.debug("www: requested to serve: %s", request.url)
 
-        path = self._resolve_path(request["url"])
+        path = self._resolve_path(request.url)
         if not path:
             return serializer.compose_error(403, "Forbidden")
 

--- a/neubot_http/www_handler.py
+++ b/neubot_http/www_handler.py
@@ -37,8 +37,6 @@ class WWWHandler(object):
     def _resolve_path(self, path):
         """ Safely maps HTTP path to filesystem path """
 
-        path = path.decode("utf-8")              # Python3
-
         logging.debug("www: rootdir %s", self.rootdir)
         logging.debug("www: original path %s", path)
 


### PR DESCRIPTION
This pull request simplifies coding with Python3 by making as much code as possible always using strings and by confining bytes to the low level. Namely:

- add output queue that automatically converts bytes to string

- use ISO-8859-1 when reading headers

- add messages classes that automatically convert the body

As a bonus, `outqueue` supports generators that return generators, thus simplifying significantly the way in which APIs are written with Python2, where `yield from` is not available.